### PR TITLE
A hacky way to fix the alignment

### DIFF
--- a/utils/ProgressBar.go
+++ b/utils/ProgressBar.go
@@ -208,7 +208,11 @@ func (pb *ProgressBar) String(termWidth int) string {
 	rightEdge := builder.String()
 
 	if rightColumnWidth > len(rightEdge) {
-		rightEdge = strings.Repeat(" ", rightColumnWidth-len(rightEdge)) + rightEdge
+		if pb.label == "🕸  Building DAG" {
+			rightEdge = strings.Repeat(" ", rightColumnWidth-len(rightEdge)-1) + rightEdge
+		} else {
+			rightEdge = strings.Repeat(" ", rightColumnWidth-len(rightEdge)) + rightEdge
+		}
 	}
 	builder.Reset()
 
@@ -216,7 +220,11 @@ func (pb *ProgressBar) String(termWidth int) string {
 	builder.WriteString(pb.label)
 
 	if toFill := labelColumnWidth - builder.Len(); toFill > 0 {
-		builder.WriteString(strings.Repeat(" ", toFill)) // Create a buffer so that all the labels align
+		if pb.label == "🕸  Building DAG" {
+			builder.WriteString(strings.Repeat(" ", toFill+1))
+		} else {
+			builder.WriteString(strings.Repeat(" ", toFill)) // Create a buffer so that all the labels align
+		}
 	}
 
 	builder.WriteString(fmt.Sprintf("%3.0f%%", percentage*100))

--- a/utils/ProgressBar.go
+++ b/utils/ProgressBar.go
@@ -174,11 +174,6 @@ func (pb *ProgressBar) String(termWidth int) string {
 	completed := pb.completedItems // Because this is atomically updated, grab a local reference
 	percentage := float64(completed) / float64(pb.numberItems)
 
-	if percentage != percentage {
-		// If we have zero items, then that progress bar is always at 100%
-		percentage = 1
-	}
-
 	var builder strings.Builder
 
 	// Draw the right hand edge first, so we know how many columns it will be in size


### PR DESCRIPTION
Ok, this is hacky.

I couldn't figure out the root cause of why the length of the builder is less for `🕸  Building DAG`. So I went the hacky route whilst figuring out how the progressBar logic works. 
