### PR TITLE
Switch out emoji to get proper alignment

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -147,7 +147,7 @@ func compileTests(fileSystem *fs.FileSystem, gc *compiler.GlobalContext) {
 }
 
 func buildGraph(fileSystem *fs.FileSystem, modelFilter string) *fs.Graph {
-	pb := utils.NewProgressBar("🕸  Building DAG", 1)
+	pb := utils.NewProgressBar("🚧 Building DAG", 1)
 	defer pb.Stop()
 
 	graph := fs.NewGraph()


### PR DESCRIPTION
As suggested when we spoke, this fixes the progress bar alignment issue.
![image](https://user-images.githubusercontent.com/6220504/96347757-b1915880-109b-11eb-985f-459532c9f35e.png)
 